### PR TITLE
668: add new attributes statuscode & dcp_ispublichearingrequired

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@types/supertest": "2.0.7",
     "jest": "24.7.1",
     "prettier": "1.17.0",
-    "supertest": "4.0.2",
+    "supertest": "5.0.0-0",
     "ts-jest": "24.0.2",
     "ts-node": "8.1.0",
     "tsc-watch": "2.2.1",

--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -87,6 +87,7 @@ SELECT
         'id', disp.dcp_communityboarddispositionid,
         'dcp_publichearinglocation', disp.dcp_publichearinglocation,
         'dcp_dateofpublichearing', disp.dcp_dateofpublichearing,
+        'dcp_ispublichearingrequired', disp.dcp_ispublichearingrequired,
         'dcp_boroughpresidentrecommendation', disp.dcp_boroughpresidentrecommendation,
         'dcp_boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
         'dcp_communityboardrecommendation', disp.dcp_communityboardrecommendation,

--- a/src/_utils/crm-web-api.ts
+++ b/src/_utils/crm-web-api.ts
@@ -360,9 +360,9 @@ export const CRMWebAPI = {
       })
   },
 
-  /** 
+  /**
     * Finds folder for an entity (like `dcp_project` or `dcp_communityboarddisposition`).
-    * Entity folders contain many instance folders, the paths of which can be 
+    * Entity folders contain many instance folders, the paths of which can be
     * acquired instead via findDocumentLocation.
     * @param { GUID } entityName - name of CRM entity, like  `dcp_project` or `dcp_communityboarddisposition`.
     * @param { string } sharepointSiteID - ID of CRM's corresponding sharepoint site. Use getParentSiteLocation() to acquire this ID
@@ -477,7 +477,7 @@ export const CRMWebAPI = {
    * @param { string } entityName - (required) Entity name like `dcp_project` or `dcp_communityboarddisposition`
    * @param { string } entityID - (required) a 32 character id, in format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
    * @param { string } folderName - (required) name of folder for entity instance. e.g '2018Q0147 - Tax Map(s) - 1_D2A818330BF0E911A997001DD832112G'
-   * This needs to be constructed by attaching the instance `dcp_name` to a formatted instance guid 
+   * This needs to be constructed by attaching the instance `dcp_name` to a formatted instance guid
    * (for projects, it is `dcp_projectid`; for dispositions, it is `dcp_communityboarddispositionid`).
    * @param { string } fileName - Desired name of the file.
    * @param { string } base64File - base64 encoded buffer
@@ -543,7 +543,7 @@ export const CRMWebAPI = {
           if (response.statusCode === 204) {
             resolve("Uploaded document successfully.")
           }
-          // If response body exists, 
+          // If response body exists,
           // allow CRM error message to bubble up.
           if (body) {
             try {

--- a/src/disposition/disposition.controller.ts
+++ b/src/disposition/disposition.controller.ts
@@ -18,11 +18,13 @@ import { OdataService } from '../odata/odata.service';
 const ATTRS_WHITELIST = [
   'dcp_publichearinglocation',
   'dcp_dateofpublichearing',
+  'dcp_ispublichearingrequired',
   'dcp_representing',
   'dcp_nameofpersoncompletingthisform',
   'dcp_title',
   'dcp_dateofvote',
   'dcp_votelocation',
+  'statuscode',
   // the sum of the other vote types must be equal to the
   // number in this column:
   'dcp_totalmembersappointedtotheboard',
@@ -67,7 +69,7 @@ export class DispositionController {
       }
     } catch (e) {
       const message = await e;
-
+        console.log(message);
       throw new HttpException({
         errors: [message],
       }, 400);

--- a/src/disposition/disposition.entity.ts
+++ b/src/disposition/disposition.entity.ts
@@ -12,6 +12,9 @@ export class Disposition {
   dcp_dateofpublichearing: string;
 
   @Column()
+  dcp_ispublichearingrequired: string;
+
+  @Column()
   form_completer_name: string;
 
   @Column()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 import { NestFactory } from '@nestjs/core';
-import * as compression from 'compression';
-import * as bodyParser from 'body-parser';
 import { AppModule } from './app.module';
 
 declare const module: any;

--- a/test/disposition.e2e-spec.ts
+++ b/test/disposition.e2e-spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import * as nock from 'nock';
+import * as rootPath from 'app-root-path';
+import * as fs from 'fs';
+import { doLogin } from './helpers/do-login';
+import { extractJWT } from './helpers/extract-jwt';
+import { AppModule } from './../src/app.module';
+import { Disposition } from './../src/disposition/disposition.entity';
+
+class DispoMock {
+  update() {} // noop
+}
+
+describe('Disposition Patch', () => {
+  let app;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+      .overrideProvider(getRepositoryToken(Disposition))
+      .useValue(new DispoMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  beforeAll(() => {
+    nock('https://login.microsoftonline.com:443')
+      .post(uri => uri.includes('oauth2/token'))
+      .reply(200, {
+        token_type: 'Bearer',
+        expires_in: '3600',
+        ext_expires_in: '3600',
+        expires_on: '1573159181',
+        not_before: '1573155281',
+        resource: 'https://dcppfsuat2.crm9.dynamics.com',
+        access_token: 'test'
+      })
+      .persist();
+
+    const scope = nock('https://dcppfsuat2.crm9.dynamics.com:443');
+
+    scope
+      .patch(uri => uri.includes('api/data/v9.1/dcp_communityboarddispositions'))
+      .reply(204, '1f8b08000000000004008c90cf4ef33010c45f2532df01a4c6ffc247eb9caa965bd50b172428428ebd014b711cc59b8a0af5ddd948c011b858b26667677ff3ced6c95bb4dca51ee10d59cd5e11875c0be1dd30b479b2a8b91ba3e1fed4db185ca6d128ec10c4ec1347c395f81701edfcbd20d333e971ea039e9a6447ef431e520e18529f2f7f94835fcc3aa5c0155bb0f53eb831e5d422bffd8adedeed3926b4dd082e8ddea5a9a7934bf5f7e92ec440a00ec08367756bbb0c0b76b4dd04ac7efcae83785ea88b7b71604a69b9bcd1faff81d155bf1090a75a36cb95b96e4a03ad29c128555ad3b8524ae5fdaa922b68d5e7a219951c5a6ab9934aaba22c1eb6f46c76c5765315053b3f9d3f0600ceb6d405a2010000', {
+        'Content-Encoding': 'gzip',
+      })
+      .persist();
+  });
+
+  test('User can submit disposition', async () => {
+    const server = app.getHttpServer();
+    const token = extractJWT(await doLogin(server, request));
+
+    return request(server)
+      .patch('/dispositions/472fc5a1-9844-e811-813d-1458d04d0698')
+      .set('Cookie', token)
+      .send({
+        data: {
+          type: 'dispositions',
+          id: '472fc5a1-9844-e811-813d-1458d04d0698',
+          attributes: {
+            dcp_publichearinglocation: "test location",
+          },
+        },
+      })
+      .expect(200)
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,7 +2599,7 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
 
@@ -2697,7 +2697,7 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
 
-cookiejar@^2.1.0:
+cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
@@ -2869,7 +2869,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -3367,7 +3367,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -3422,7 +3422,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fast-safe-stringify@2.0.7:
+fast-safe-stringify@2.0.7, fast-safe-stringify@^2.0.6:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
 
@@ -3536,7 +3536,7 @@ fork-ts-checker-webpack-plugin@3.0.1:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-form-data@^2.3.1:
+form-data@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   dependencies:
@@ -3552,7 +3552,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.2.0:
+formidable@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
@@ -5016,7 +5016,7 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
 
-methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
+methods@1.1.2, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -5070,9 +5070,13 @@ mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.40.0"
 
-mime@1.6.0, mime@^1.4.1:
+mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
+mime@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
 
 mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
@@ -5946,7 +5950,7 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
 
-qs@^6.5.1:
+qs@^6.7.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
 
@@ -6036,7 +6040,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -6056,6 +6060,14 @@ readable-stream@1.1.x:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@~1.0.31:
   version "1.0.34"
@@ -6329,7 +6341,7 @@ semver@4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
 
-semver@^6.0.0, semver@^6.2.0:
+semver@^6.0.0, semver@^6.1.1, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
 
@@ -6685,7 +6697,7 @@ string.prototype.trimright@^2.0.0:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string_decoder@^1.0.0:
+string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   dependencies:
@@ -6731,27 +6743,28 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-superagent@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+superagent@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.1.0.tgz#9ce4f38bee64d65a56166423b573222fa1b8f041"
   dependencies:
-    component-emitter "^1.2.0"
-    cookiejar "^2.1.0"
-    debug "^3.1.0"
-    extend "^3.0.0"
-    form-data "^2.3.1"
-    formidable "^1.2.0"
-    methods "^1.1.1"
-    mime "^1.4.1"
-    qs "^6.5.1"
-    readable-stream "^2.3.5"
-
-supertest@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
-  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.6"
+    form-data "^2.3.3"
+    formidable "^1.2.1"
     methods "^1.1.2"
-    superagent "^3.8.3"
+    mime "^2.4.4"
+    qs "^6.7.0"
+    readable-stream "^3.4.0"
+    semver "^6.1.1"
+
+supertest@^5.0.0:
+  version "5.0.0-0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-5.0.0-0.tgz#7e6febb93d7b7c3eafd94dafc2b4ff2ee4cb9c99"
+  dependencies:
+    methods "1.1.2"
+    superagent "5.1.0"
 
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"
@@ -7233,7 +7246,7 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
### Changes:
- Add new read/write attribute `dcp_ispublichearingrequired` which is set to `no` if a user opts out of submitting hearings
- Add new read/write attribute `statuscode` which is set to `Submitted` when a user submits a recommendation

### Tests:
- new test in `app.e2e-spec.ts` for patching dispositions

Frontend changes for this issue are already implemented
Addresses [#668](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/668)