### PR TITLE
895: add dcp_recommendationsubmittedbyname as an attribute to disposition

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -88,6 +88,7 @@ SELECT
         'dcp_publichearinglocation', disp.dcp_publichearinglocation,
         'dcp_dateofpublichearing', disp.dcp_dateofpublichearing,
         'dcp_ispublichearingrequired', disp.dcp_ispublichearingrequired,
+        'dcp_recommendationsubmittedbyname', disp.dcp_recommendationsubmittedbyname,
         'dcp_boroughpresidentrecommendation', disp.dcp_boroughpresidentrecommendation,
         'dcp_boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
         'dcp_communityboardrecommendation', disp.dcp_communityboardrecommendation,

--- a/src/disposition/disposition.entity.ts
+++ b/src/disposition/disposition.entity.ts
@@ -15,6 +15,9 @@ export class Disposition {
   dcp_ispublichearingrequired: string;
 
   @Column()
+  dcp_recommendationsubmittedbyname: string;
+
+  @Column()
   form_completer_name: string;
 
   @Column()


### PR DESCRIPTION
Sub-milestones feature in the frontend uses `dcp_recommendationsubmittedbyname` field. 

Because this is often NULL in the database, we should work on possibly finding a better field to accomplish this. 

Addresses [#895](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/895)