### PR TITLE
Test assignment keys in response

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -116,7 +116,8 @@ lups_project_assignments_filtered AS (
   SELECT
     dcp_lupteammemberrole,
     dcp_project AS project_id,
-    tab
+    tab,
+    assignmentid AS id
   FROM lups_project_assignments_with_tab
   WHERE
     dcp_lupteammemberrole <> 'BB'

--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -1,14 +1,15 @@
 -- first, get the list of assigned projects, roles, and statuses for the specific LUP contact
 WITH lups_project_assignments_all AS (
   SELECT DISTINCT
-    CONCAT(dcp_lupteammemberrole,'-',dcp_project) AS assignmentid,
+    dcp_projectlupteamid, -- important! this is the unique ID used for assignments
+    CONCAT(dcp_lupteammemberrole,'-',dcp_project) AS assignment_check, -- this is purely for joining tables and making sure the correct role matches were found
     dcp_project,
     dcp_lupteammemberrole
   FROM
     dcp_projectlupteam
   WHERE
     dcp_lupteammember = '${id:value}' -- plugs in contactid
-    AND statuscode = 'Active'
+    AND statuscode = 'Active' -- only want lup project assignments that haven't been deactivated
 ),
 
 -- get the public status of the LUP's assigned projects
@@ -34,7 +35,7 @@ lups_review_milestones AS (
   WHERE
     dcp_projectmilestone.statuscode <> 'Overridden'
     AND dcp_projectmilestone.dcp_project = lups_project_assignments_all.dcp_project
-    AND (
+    AND ( -- this filters down to only keep the milestones that match our user's role
       (dcp_projectmilestone.dcp_milestone = '923beec4-dad0-e711-8116-1458d04e2fb8' AND lups_project_assignments_all.dcp_lupteammemberrole = 'CB')
       OR (dcp_projectmilestone.dcp_milestone = '943beec4-dad0-e711-8116-1458d04e2fb8' AND lups_project_assignments_all.dcp_lupteammemberrole = 'BP')
       OR (dcp_projectmilestone.dcp_milestone = '963beec4-dad0-e711-8116-1458d04e2fb8' AND lups_project_assignments_all.dcp_lupteammemberrole = 'BB')
@@ -46,8 +47,8 @@ lups_dispositions_status AS (
   SELECT
     lups_project_assignments_all.*,
     dcp_communityboarddisposition.dcp_visibility AS dcp_visibility,
-    dcp_communityboarddisposition.statecode AS statecode,
-    dcp_communityboarddisposition.statuscode AS statuscode
+    dcp_communityboarddisposition.statecode AS statecode, -- inactive or active
+    dcp_communityboarddisposition.statuscode AS statuscode -- more descriptive status of draft, saved, submitted, deactivated
   FROM
     lups_project_assignments_all,
     dcp_communityboarddisposition
@@ -67,7 +68,8 @@ lups_dispositions_status AS (
     dcp_communityboarddisposition.statuscode,
     lups_project_assignments_all.dcp_project,
     lups_project_assignments_all.dcp_lupteammemberrole,
-    lups_project_assignments_all.assignmentid
+    lups_project_assignments_all.dcp_projectlupteamid,
+    lups_project_assignments_all.assignment_check
 ),
 
 -- join all the tables onto the lups_project_assignments and determine which "tab" each assignment belongs on
@@ -79,19 +81,19 @@ lups_project_assignments_with_tab AS (
         THEN 'archive'
       WHEN
         lups_review_milestones.statuscode = 'Not Started'
-        OR projects_public_statuses.dcp_publicstatus = 'Filed'
+        OR projects_public_statuses.dcp_publicstatus = 'Filed' -- included bc sometimes the milestone status isn't filled in
         THEN 'upcoming'
       WHEN
         lups_review_milestones.statuscode IN ('In Progress', 'Completed')
         AND projects_public_statuses.dcp_publicstatus NOT IN ('Approved', 'Withdrawn/Terminated/Disapproved', 'Disapproved')
         AND lups_dispositions_status.statecode = 'Active'
-        AND lups_dispositions_status.statuscode IN ('Draft', 'Saved')
+        AND lups_dispositions_status.statuscode IN ('Draft', 'Saved') -- draft status before LUP makes any edits, saved status after they've submitted hearing
         THEN 'to-review'
       WHEN
         lups_review_milestones.statuscode IN ('In Progress', 'Completed')
         AND projects_public_statuses.dcp_publicstatus NOT IN ('Approved', 'Withdrawn/Terminated/Disapproved', 'Disapproved')
         AND lups_dispositions_status.statecode = 'Inactive'
-        AND lups_dispositions_status.statuscode IN ('Submitted', 'Not Submitted')
+        AND lups_dispositions_status.statuscode IN ('Submitted', 'Not Submitted') -- status becomes submitted once they submit recommendation
         THEN 'reviewed'
     END AS tab,
     lups_project_assignments_all.*,
@@ -106,21 +108,21 @@ lups_project_assignments_with_tab AS (
   INNER JOIN -- inner because we only want projects that are visible to public
     projects_public_statuses ON lups_project_assignments_all.dcp_project = projects_public_statuses.dcp_projectid
   LEFT JOIN
-    lups_dispositions_status ON lups_project_assignments_all.assignmentid = lups_dispositions_status.assignmentid
+    lups_dispositions_status ON lups_project_assignments_all.assignment_check = lups_dispositions_status.assignment_check
   LEFT JOIN
-    lups_review_milestones ON lups_project_assignments_all.assignmentid = lups_review_milestones.assignmentid
+    lups_review_milestones ON lups_project_assignments_all.assignment_check = lups_review_milestones.assignment_check
 ),
 
 -- filter the previous table; we only want to see the BB assignment card for to-review projects and post-cert projects in upcoming
 lups_project_assignments_filtered AS (
   SELECT
+    dcp_projectlupteamid AS id,
     dcp_lupteammemberrole,
     dcp_project AS project_id,
-    tab,
-    assignmentid AS id
+    tab
   FROM lups_project_assignments_with_tab
   WHERE
-    dcp_lupteammemberrole <> 'BB'
+    dcp_lupteammemberrole <> 'BB' -- this drops all BB records except for the two conditions below
     OR (dcp_lupteammemberrole = 'BB' AND tab = 'upcoming' AND dcp_publicstatus = 'Certified/Referred')
     OR (dcp_lupteammemberrole = 'BB' AND tab = 'to-review')
 )

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -39,7 +39,6 @@ export class AssignmentController {
 
     // This is wrong... the wrong approach.
     const AssignmentSerializer = new Serializer('assignments', {
-      id: 'dcp_name',
       attributes: Object.keys(assignment),
       project: {
         ref: 'dcp_name',
@@ -63,8 +62,8 @@ export class AssignmentController {
       },
       ...(milestone ? {
         milestones: {
-          ref(project, milestone) {
-            return `${project.dcp_name}-${milestone.dcp_milestone}`;
+          ref(assignment, milestone) {
+            return `${assignment.project.dcp_name}-${milestone.dcp_milestone}`;
           },
           attributes: Object.keys(milestone),
         },

--- a/test/assignment.e2e-spec.ts
+++ b/test/assignment.e2e-spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import * as nock from 'nock';
+import * as rootPath from 'app-root-path';
+import * as fs from 'fs';
+import { doLogin } from './helpers/do-login';
+import { extractJWT } from './helpers/extract-jwt';
+import { AppModule } from './../src/app.module';
+import { Project } from './../src/project/project.entity';
+import { strict as assert } from 'assert';
+
+// class AssignMock {
+//   update() {} // noop
+// }
+
+async function checkResponse(response) {
+  const boop = await response.body.data[0];
+  const boopProps = Object.keys(boop);
+  console.log('boopProps', boopProps);
+  if (!boopProps.includes('peach')) {
+    console.log('it is erroringggg');
+    throw new Error('There is no property peach');
+  }
+  // console.log('boop', ob
+  // console.log('peaches', boop);
+}
+
+describe('Assignment Get', () => {
+  let app;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+      // .overrideProvider(getRepositoryToken(Project))
+      // .useValue(new AssignMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  beforeAll(() => {
+    nock('https://login.microsoftonline.com:443')
+      .post(uri => uri.includes('oauth2/token'))
+      .reply(200, {
+        token_type: 'Bearer',
+        expires_in: '3600',
+        ext_expires_in: '3600',
+        expires_on: '1573159181',
+        not_before: '1573155281',
+        resource: 'https://dcppfsuat2.crm9.dynamics.com',
+        access_token: 'test'
+      })
+      .persist();
+
+    const scope = nock('https://dcppfsuat2.crm9.dynamics.com:443');
+
+    scope
+      .get(uri => uri.includes('api/data/v9.1/dcp_projects'))
+      .reply(200, '1f8b08000000000004008c8fcd4ec33010845f255a38b452127b9d407e4e454085847a29070e1421cbde80511247b1538150df1d17155438711c6b3eef371fb0b05a7a992adb7b7af350c38bf783ab19d36a181a37492f52357655aadf7bd919e542b56372306ccfb16d95223bedc8cb7d3c09d0d330da5752decd8e4240293eca467fa5fdf31c6258ac8c1aadb38d4fafbecf5cae57a9b75eb623293b6a65a73ee825f8ff766b3a134629224d1aea46b68e62d8ca7622a81f7ea607f7e7b0fb9e6d0051f0e21cf37203c1ea8f7fe8206679b49c5a6ffbe8624bfd44d16cb9bebebb99ffae9b700e1acace50949464852c12aa101359954dc2396a5d66bce47971c00edf0b2ef82d4781b07bdc7d0e000e5597419b010000', {
+        'Content-Encoding': 'gzip',
+      })
+      .persist();
+  });
+
+  test('Get correct assignment keys', async () => {
+    const server = app.getHttpServer(); // UAT2 server
+    const token = extractJWT(await doLogin(server, request)); // token that is passed with each request
+
+    return request(server)
+      .get('/assignments?include=project.milestones%2Cproject.dispositions%2Cproject.actions&tab=upcoming')
+      .set('Cookie', token)
+      .expect(200)
+      .then(async response => {
+        const firstData = await response.body.data[0];
+        expect(firstData).toHaveProperty("id")
+        expect(firstData).toHaveProperty("relationships")
+        expect(firstData).toHaveProperty("type", "assignments")
+
+        const attributes = await response.body.data[0].attributes;
+        expect(attributes).toHaveProperty("actualenddate")
+        expect(attributes).toHaveProperty("actualstartdate")
+        expect(attributes).toHaveProperty("dcp-lupteammemberrole")
+        expect(attributes).toHaveProperty("dcp-name")
+        expect(attributes).toHaveProperty("dcp-projectbrief")
+        expect(attributes).toHaveProperty("dcp-projectname")
+        expect(attributes).toHaveProperty("dcp-publicstatus")
+        expect(attributes).toHaveProperty("dcp-ulurp-nonulurp")
+        expect(attributes).toHaveProperty("lup-name")
+
+        expect(attributes).toHaveProperty("plannedcompletiondate")
+        expect(attributes).toHaveProperty("plannedstartdate")
+        expect(attributes).toHaveProperty("project-applicantteam")
+
+        expect(attributes).toHaveProperty("project-id")
+        expect(attributes).toHaveProperty("tab", "upcoming")
+        expect(attributes).toHaveProperty("dcp-ulurp-nonulurp")
+        expect(attributes).toHaveProperty("lup-name")
+      });
+
+  });
+});

--- a/test/assignment.e2e-spec.ts
+++ b/test/assignment.e2e-spec.ts
@@ -10,22 +10,6 @@ import { AppModule } from './../src/app.module';
 import { Project } from './../src/project/project.entity';
 import { strict as assert } from 'assert';
 
-// class AssignMock {
-//   update() {} // noop
-// }
-
-async function checkResponse(response) {
-  const boop = await response.body.data[0];
-  const boopProps = Object.keys(boop);
-  console.log('boopProps', boopProps);
-  if (!boopProps.includes('peach')) {
-    console.log('it is erroringggg');
-    throw new Error('There is no property peach');
-  }
-  // console.log('boop', ob
-  // console.log('peaches', boop);
-}
-
 describe('Assignment Get', () => {
   let app;
 
@@ -33,38 +17,14 @@ describe('Assignment Get', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
         imports: [AppModule],
       })
-      // .overrideProvider(getRepositoryToken(Project))
-      // .useValue(new AssignMock)
       .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
   });
 
-  beforeAll(() => {
-    nock('https://login.microsoftonline.com:443')
-      .post(uri => uri.includes('oauth2/token'))
-      .reply(200, {
-        token_type: 'Bearer',
-        expires_in: '3600',
-        ext_expires_in: '3600',
-        expires_on: '1573159181',
-        not_before: '1573155281',
-        resource: 'https://dcppfsuat2.crm9.dynamics.com',
-        access_token: 'test'
-      })
-      .persist();
-
-    const scope = nock('https://dcppfsuat2.crm9.dynamics.com:443');
-
-    scope
-      .get(uri => uri.includes('api/data/v9.1/dcp_projects'))
-      .reply(200, '1f8b08000000000004008c8fcd4ec33010845f255a38b452127b9d407e4e454085847a29070e1421cbde80511247b1538150df1d17155438711c6b3eef371fb0b05a7a992adb7b7af350c38bf783ab19d36a181a37492f52357655aadf7bd919e542b56372306ccfb16d95223bedc8cb7d3c09d0d330da5752decd8e4240293eca467fa5fdf31c6258ac8c1aadb38d4fafbecf5cae57a9b75eb623293b6a65a73ee825f8ff766b3a134629224d1aea46b68e62d8ca7622a81f7ea607f7e7b0fb9e6d0051f0e21cf37203c1ea8f7fe8206679b49c5a6ffbe8624bfd44d16cb9bebebb99ffae9b700e1acace50949464852c12aa101359954dc2396a5d66bce47971c00edf0b2ef82d4781b07bdc7d0e000e5597419b010000', {
-        'Content-Encoding': 'gzip',
-      })
-      .persist();
-  });
-
+  // NOTE: this test is actually hitting the database. it maybe fail due to a timeout.
+  // if this happens rerun the test. in the long-run, get a real test database!
   test('Get correct assignment keys', async () => {
     const server = app.getHttpServer(); // UAT2 server
     const token = extractJWT(await doLogin(server, request)); // token that is passed with each request
@@ -74,31 +34,13 @@ describe('Assignment Get', () => {
       .set('Cookie', token)
       .expect(200)
       .then(async response => {
-        const firstData = await response.body.data[0];
-        expect(firstData).toHaveProperty("id")
-        expect(firstData).toHaveProperty("relationships")
-        expect(firstData).toHaveProperty("type", "assignments")
+        const [assignment] = await response.body.data;
 
-        const attributes = await response.body.data[0].attributes;
-        expect(attributes).toHaveProperty("actualenddate")
-        expect(attributes).toHaveProperty("actualstartdate")
-        expect(attributes).toHaveProperty("dcp-lupteammemberrole")
-        expect(attributes).toHaveProperty("dcp-name")
-        expect(attributes).toHaveProperty("dcp-projectbrief")
-        expect(attributes).toHaveProperty("dcp-projectname")
-        expect(attributes).toHaveProperty("dcp-publicstatus")
-        expect(attributes).toHaveProperty("dcp-ulurp-nonulurp")
-        expect(attributes).toHaveProperty("lup-name")
-
-        expect(attributes).toHaveProperty("plannedcompletiondate")
-        expect(attributes).toHaveProperty("plannedstartdate")
-        expect(attributes).toHaveProperty("project-applicantteam")
-
-        expect(attributes).toHaveProperty("project-id")
-        expect(attributes).toHaveProperty("tab", "upcoming")
-        expect(attributes).toHaveProperty("dcp-ulurp-nonulurp")
-        expect(attributes).toHaveProperty("lup-name")
+        expect(assignment).toHaveProperty('id')
+        expect(assignment).toHaveProperty('relationships')
+        expect(assignment).toHaveProperty('type', 'assignments')
+        expect(assignment).toHaveProperty('attributes.dcp-lupteammemberrole')
+        expect(assignment).toHaveProperty('attributes.tab', 'upcoming')
       });
-
-  });
+  }, 30000);
 });


### PR DESCRIPTION
This PR changes the query so that an unique identifier isalways provided with the assignment.

Fixes the way the json:api serializer was creating matching reliatinoships with identifiers.

~DO NOT MERGE:~

~Still some missing logic in the query:~

> Error: Assertion Failed: You looked up the 'dispositions' relationship on a 'assignment' with id BP-676feca2-7646-e911-8151-1458d04d06c8 but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async 
