### PR TITLE
Handle serialization of project(s) explicitly

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -200,6 +200,7 @@ SELECT
   ) AS dispositions,
   (
     SELECT json_agg(json_build_object(
+      'id', m.dcp_projectmilestoneid,
       'dcp_name', m.dcp_name,
       'milestonename', m.milestonename,
       'dcp_plannedstartdate', m.dcp_plannedstartdate,
@@ -439,6 +440,7 @@ SELECT
         ) AS addresses,
         (
           SELECT json_agg(json_build_object(
+            'id', a.dcp_projectactionid,
             'dcp_name', SUBSTRING(a.dcp_name FROM '-{1}\s*(.*)'), -- use regex to pull out action name -{1}(.*)
             'actioncode', SUBSTRING(a.dcp_name FROM '^(\w+)'),
             'dcp_ulurpnumber', a.dcp_ulurpnumber,
@@ -530,6 +532,7 @@ SELECT
         ) AS actions,
         (
           SELECT json_agg(json_build_object(
+            'id', m.dcp_projectmilestoneid,
             'dcp_name', m.dcp_name,
             'milestonename', m.milestonename,
             'dcp_plannedstartdate', m.dcp_plannedstartdate,

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -46,6 +46,7 @@ SELECT
   ) AS bbl_multipolygon,
   (
     SELECT json_agg(json_build_object(
+      'id', a.dcp_projectactionid,
       'dcp_name', SUBSTRING(a.dcp_name FROM '-{1}\s*(.*)'), -- use regex to pull out action name -{1}(.*)
       'actioncode', SUBSTRING(a.dcp_name FROM '^(\w+)'),
       'dcp_ulurpnumber', a.dcp_ulurpnumber,
@@ -137,6 +138,7 @@ SELECT
   ) AS actions,
   (
     SELECT json_agg(json_build_object(
+      'id', m.dcp_projectmilestoneid,
       'dcp_name', m.dcp_name,
       'milestonename', m.milestonename,
       'dcp_plannedstartdate', m.dcp_plannedstartdate,

--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -46,7 +46,6 @@ export class AssignmentController {
       if (!record.milestones) record.milestones = [];
     });
 
-    // This is wrong... the wrong approach.
     const AssignmentSerializer = new Serializer('assignments', {
       attributes: ASSIGNMENT_KEYS,
       project: {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -152,17 +152,12 @@ export class ProjectService {
       id: 'dcp_name',
       attributes: PROJECT_KEYS,
       actions: {
-        ref(project, action) {
-          console.log(project);
-          return `${project.dcp_name}-${action.actioncode}`;
-        },
+        ref: 'id',
         attributes: ACTION_KEYS,
       },
 
       milestones: {
-        ref(project, milestone) {
-          return `${project.dcp_name}-${milestone.dcp_milestone}`;
-        },
+        ref: 'id',
         attributes: MILESTONE_KEYS,
       },
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -13,7 +13,8 @@ import { ConfigService } from '../config/config.service';
 import { TilesService } from './tiles/tiles.service';
 import { getQueryFile } from '../_utils/get-query-file';
 import { buildProjectsSQL } from './_utils/build-projects-sql';
-import { Project } from './project.entity';
+import { Project, KEYS as PROJECT_KEYS, ACTION_KEYS, MILESTONE_KEYS } from './project.entity';
+import { KEYS as DISPOSITION_KEYS } from '../disposition/disposition.entity';
 
 const findProjectQuery = getQueryFile('/projects/show.sql');
 const boundingBoxQuery = getQueryFile('helpers/bounding-box-query.sql');
@@ -147,37 +148,29 @@ export class ProjectService {
 
   // Serializes an array of objects into a JSON:API document
   serialize(records, opts?: object): Serializer {
-    let [project] = (records.length ? records : [records]);
-    const [action = {}] = project.actions || [];
-    const [milestone = {}] = project.milestones || [];
-    const [disposition = {}] = project.dispositions || [];
-
-    // This is wrong... the wrong approach.
     const ProjectSerializer = new Serializer('projects', {
       id: 'dcp_name',
-      attributes: Object.keys(project),
-      ...(action ? {
-        actions: {
-          ref(project, action) {
-            return `${project.dcp_name}-${action.actioncode}`;
-          },
-          attributes: Object.keys(action),
+      attributes: PROJECT_KEYS,
+      actions: {
+        ref(project, action) {
+          console.log(project);
+          return `${project.dcp_name}-${action.actioncode}`;
         },
-      } : {}),
-      ...(milestone ? {
-        milestones: {
-          ref(project, milestone) {
-            return `${project.dcp_name}-${milestone.dcp_milestone}`;
-          },
-          attributes: Object.keys(milestone),
+        attributes: ACTION_KEYS,
+      },
+
+      milestones: {
+        ref(project, milestone) {
+          return `${project.dcp_name}-${milestone.dcp_milestone}`;
         },
-      } : {}),
-      ...(disposition ? {
-        dispositions: {
-          ref: 'id',
-          attributes: Object.keys(disposition),
-        },
-      } : {}),
+        attributes: MILESTONE_KEYS,
+      },
+
+      dispositions: {
+        ref: 'id',
+        attributes: DISPOSITION_KEYS,
+      },
+
       meta: { ...opts },
     });
 


### PR DESCRIPTION
This PR reworks how serialization is handled in project(s). Now, it explicitly defines entity key names which are defined on respective entity files during the serialization step.

Let's hold off this for now until more extensive testing