### PR TITLE
22: fix materialized view query for ulurp numbers

### DIFF
--- a/migrations/materialized-view-definition.sql
+++ b/migrations/materialized-view-definition.sql
@@ -20,7 +20,7 @@ LEFT JOIN (
   SELECT *
   FROM dcp_projectaction
   WHERE statuscode <> 'Mistake'
-  AND SUBSTRING(dcp_name FROM '^(\\w+)') IN (
+  AND LEFT(dcp_name, 2) IN (
     'BD',
     'BF',
     'CM',


### PR DESCRIPTION
This solves https://github.com/NYCPlanning/zap-api/issues/22

Not sure why the original regex query stopped working, but the ulurpnumbers column in the materialized view was full of NULL values because the WHERE condition didn't find any results. This fixes it.

I've already run the revised SQL definition on the staging database to test that it works. Once this is approved, I'll apply it on production too.