### PR TITLE
948: left join contact.fullname to disposition table for sub-milestones refactor

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -155,7 +155,8 @@ SELECT
         'dcp_publichearinglocation', disp.dcp_publichearinglocation,
         'dcp_dateofpublichearing', disp.dcp_dateofpublichearing,
         'dcp_ispublichearingrequired', disp.dcp_ispublichearingrequired,
-        'dcp_recommendationsubmittedbyname', disp.dcp_recommendationsubmittedbyname,
+        'dcp_recommendationsubmittedby', disp.dcp_recommendationsubmittedby,
+        'fullname', contact.fullname,
         'dcp_boroughpresidentrecommendation', disp.dcp_boroughpresidentrecommendation,
         'dcp_boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
         'dcp_communityboardrecommendation', disp.dcp_communityboardrecommendation,
@@ -192,6 +193,7 @@ SELECT
     )
     FROM dcp_communityboarddisposition AS disp
     LEFT JOIN dcp_projectaction AS pact ON disp.dcp_projectaction = pact.dcp_action
+    LEFT JOIN contact ON dcp_recommendationsubmittedby = contact.contactid
     WHERE
       disp.dcp_project = p.dcp_projectid
       AND disp.dcp_recommendationsubmittedby = ${id} -- plugs in contactid
@@ -728,6 +730,7 @@ SELECT
               'dcp_name', pact.dcp_name,
               'dcp_ulurpnumber', pact.dcp_ulurpnumber,
               'recommendationsubmittedby', disp.dcp_recommendationsubmittedby,
+              'fullname', contact.fullname,
               'representing', disp.dcp_representing,
               'dateofpublichearing', disp.dcp_dateofpublichearing,
               'boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
@@ -739,6 +742,7 @@ SELECT
           )
           FROM dcp_communityboarddisposition AS disp
           LEFT JOIN dcp_projectaction AS pact ON disp.dcp_projectaction = pact.dcp_action
+          LEFT JOIN contact ON dcp_recommendationsubmittedby = contact.contactid
           WHERE
             -- note: we want to get all dispositions, but we only want to show the public ones WHERE statuscode IN ('Saved', 'Submitted')
             disp.dcp_project = p.dcp_projectid

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -365,6 +365,7 @@ SELECT
         'dcp_totalmembersappointedtotheboard', disp.dcp_totalmembersappointedtotheboard,
         'dcp_wasaquorumpresent', disp.dcp_wasaquorumpresent,
         'recommendationsubmittedby', disp.dcp_recommendationsubmittedby,
+        'fullname', contact.fullname,
         'representing', disp.dcp_representing,
         'dateofpublichearing', disp.dcp_dateofpublichearing,
         'boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
@@ -375,6 +376,7 @@ SELECT
       )
     )
     FROM dcp_communityboarddisposition AS disp
+    LEFT JOIN contact ON dcp_recommendationsubmittedby = contact.contactid
     WHERE
       disp.dcp_project = p.dcp_projectid
   ) AS dispositions

--- a/src/contact/contact.entity.ts
+++ b/src/contact/contact.entity.ts
@@ -7,4 +7,7 @@ export class Contact {
 
   @Column()
   emailaddress1: string;
+
+  @Column()
+  fullname: string;
 }

--- a/src/disposition/disposition.entity.ts
+++ b/src/disposition/disposition.entity.ts
@@ -4,7 +4,7 @@ export const KEYS = [
   'dcp_publichearinglocation',
   'dcp_ispublichearingrequired',
   'dcp_dateofpublichearing',
-  'dcp_recommendationsubmittedbyname',
+  'dcp_recommendationsubmittedby',
   'dcp_boroughpresidentrecommendation',
   'dcp_boroughboardrecommendation',
   'dcp_communityboardrecommendation',
@@ -37,7 +37,7 @@ export class Disposition {
   dcp_ispublichearingrequired: string;
 
   @Column()
-  dcp_recommendationsubmittedbyname: string;
+  dcp_recommendationsubmittedby: string;
 
   @Column()
   form_completer_name: string;

--- a/test/assignment.e2e-spec.ts
+++ b/test/assignment.e2e-spec.ts
@@ -41,6 +41,12 @@ describe('Assignment Get', () => {
         expect(assignment).toHaveProperty('type', 'assignments')
         expect(assignment).toHaveProperty('attributes.dcp-lupteammemberrole')
         expect(assignment).toHaveProperty('attributes.tab', 'upcoming')
+
+        const relationships = await response.body.data[0].relationships;
+
+        expect(relationships).toHaveProperty('dispositions')
+        expect(relationships).toHaveProperty('milestones')
+        expect(relationships).toHaveProperty('project')
       });
   }, 30000);
 

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import * as nock from 'nock';
+import * as rootPath from 'app-root-path';
+import * as fs from 'fs';
+import { doLogin } from './helpers/do-login';
+import { extractJWT } from './helpers/extract-jwt';
+import { AppModule } from './../src/app.module';
+import { Project } from './../src/project/project.entity';
+import { strict as assert } from 'assert';
+
+describe('Project Get', () => {
+  let app;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  // NOTE: this test is actually hitting the database. it maybe fail due to a timeout.
+  // if this happens rerun the test. in the long-run, get a real test database!
+  test('Get correct project keys', async () => {
+    const server = app.getHttpServer(); // UAT2 server
+    const token = extractJWT(await doLogin(server, request)); // token that is passed with each request
+
+    return request(server)
+      .get('/projects?include=project.milestones%2Cproject.dispositions%2Cproject.actions')
+      .set('Cookie', token)
+      .expect(200)
+      .then(async response => {
+        const [project] = await response.body.data;
+
+        expect(project).toHaveProperty('id')
+        expect(project).toHaveProperty('type', 'projects')
+        expect(project).toHaveProperty('attributes.actiontypes')
+        expect(project).toHaveProperty('attributes.applicants')
+        expect(project).toHaveProperty('attributes.center')
+        expect(project).toHaveProperty('attributes.dcp-borough')
+        expect(project).toHaveProperty('attributes.dcp-ceqrnumber')
+        expect(project).toHaveProperty('attributes.dcp-ceqrtype')
+        expect(project).toHaveProperty('attributes.dcp-certifiedreferred')
+        expect(project).toHaveProperty('attributes.dcp-communitydistricts')
+        expect(project).toHaveProperty('attributes.dcp-femafloodzonea')
+        expect(project).toHaveProperty('attributes.dcp-femafloodzonecoastala')
+        expect(project).toHaveProperty('attributes.dcp-femafloodzoneshadedx')
+        expect(project).toHaveProperty('attributes.dcp-femafloodzonev')
+        expect(project).toHaveProperty('attributes.dcp-name')
+        expect(project).toHaveProperty('attributes.dcp-projectbrief')
+        expect(project).toHaveProperty('attributes.dcp-projectname')
+        expect(project).toHaveProperty('attributes.dcp-publicstatus-simp')
+        expect(project).toHaveProperty('attributes.dcp-ulurp-nonulurp')
+        expect(project).toHaveProperty('attributes.has-centroid')
+        expect(project).toHaveProperty('attributes.lastmilestonedate')
+        expect(project).toHaveProperty('attributes.total-projects')
+        expect(project).toHaveProperty('attributes.ulurpnumbers')
+      });
+  }, 30000);
+});


### PR DESCRIPTION
### Changes:

- add field `dcp_recommendationsubmittedby` for disposition
- join contact table to `dcp_communityboarddisposition` so that we have access to `contact.fullname` field on each disposition
- this `fullname` field will replace `dcp_recommendationsubmittedbyname` field in frontend for sub-milestones feature

### Tests:

- Add test for `project.e2e-spec` property validation
- Check for relationships in `assignment.e2e-spec` test

Wasn't sure how to test for the fields we're getting from disposition because we don't have a `GET` for that, only a `PATCH` -- will take any suggestions

Addresses [#948](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/948)

