### PR TITLE
976: revise action id and add dcp_projectaction to disposition

### DIFF
--- a/src/assignment/assignment.controller.ts
+++ b/src/assignment/assignment.controller.ts
@@ -56,9 +56,7 @@ export class AssignmentController {
         ref: 'dcp_name',
         attributes: PROJECT_KEYS,
         actions: {
-          ref(project, action) {
-            return `${project.dcp_name}-${action.actioncode}`;
-          },
+          ref: 'id',
           attributes: ACTION_KEYS,
         },
         milestones: {

--- a/src/disposition/disposition.entity.ts
+++ b/src/disposition/disposition.entity.ts
@@ -21,6 +21,7 @@ export const KEYS = [
   'dcp_votingabstainingonrecommendation',
   'dcp_totalmembersappointedtotheboard',
   'dcp_wasaquorumpresent',
+  'dcp_projectaction'
 ];
 
 @Entity('dcp_communityboarddisposition')
@@ -93,4 +94,7 @@ export class Disposition {
 
   @Column()
   dcp_wasaquorumpresent: string;
+
+  @Column()
+  dcp_projectaction: string;
 }


### PR DESCRIPTION
- update action id to be sourced from `dcp_projectactionid` field
- add `dcp_projectaction` to disposition so we have access to action id

Closes [#976](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/976) and connected to frontend PR https://github.com/NYCPlanning/labs-zap-search/pull/998