### PR TITLE
52: exclude project status from lup tab logic

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -84,13 +84,11 @@ lups_project_assignments_with_tab AS (
         THEN 'upcoming'
       WHEN
         lups_review_milestones.statuscode IN ('In Progress', 'Completed')
-        AND projects_public_statuses.dcp_publicstatus NOT IN ('Approved', 'Withdrawn/Terminated/Disapproved', 'Disapproved')
         AND lups_dispositions_status.statecode IN ('Active', '0')
         AND lups_dispositions_status.statuscode IN ('Draft', 'Saved', '1', '717170000') -- draft status before LUP makes any edits, saved status after they've submitted hearing
         THEN 'to-review'
       WHEN
         lups_review_milestones.statuscode IN ('In Progress', 'Completed')
-        AND projects_public_statuses.dcp_publicstatus NOT IN ('Approved', 'Withdrawn/Terminated/Disapproved', 'Disapproved')
         AND lups_dispositions_status.statecode IN ('Inactive', '1')
         AND lups_dispositions_status.statuscode IN ('Submitted', 'Not Submitted', '2', '717170002') -- status becomes submitted once they submit recommendation
         THEN 'reviewed'


### PR DESCRIPTION
Updates logic for sorting LUP assignments on to tabs. A few notes:
- Removed project's dcp_publicstatus logic for to-review and reviewed tabs
- Keeps dcp_publicstatus logic for archive because we don't have another way of knowing if the project is done
- Only uses dcp_publicstatus logic as an "OR" option for upcoming to catch cases where the LUP's review milestone is missing a status

These changes didn't impact anything for the MN BP and BK BP assignments. For QN BP, it changed one NULL tab record to be to-review which is good I'm assuming.