### PR TITLE
874 new migration to create normalized_projects w actiontypes

### DIFF
--- a/migrations/materialized-view-definition.sql
+++ b/migrations/materialized-view-definition.sql
@@ -8,7 +8,7 @@ SELECT dcp_project.*,
     WHEN dcp_project.dcp_publicstatus = 'Withdrawn/Terminated/Disapproved' THEN 'Completed'
     ELSE 'Unknown'
   END AS dcp_publicstatus_simp,
-  STRING_AGG(DISTINCT SUBSTRING(actions.dcp_name FROM '^(\\w+)'), ';') AS actiontypes,
+  STRING_AGG(DISTINCT LEFT(actions.dcp_name, 2), ';') AS actiontypes,
   STRING_AGG(DISTINCT actions.dcp_ulurpnumber, ';') AS ulurpnumbers,
   STRING_AGG(DISTINCT dcp_projectbbl.dcp_validatedblock, ';') AS blocks,
   STRING_AGG(DISTINCT dcp_projectbbl.dcp_bblnumber, ';') as bbls,


### PR DESCRIPTION
Edits `materialized-view-definition.sql`, replacing a regex expression on line 11 with `LEFT(actions.dcp_name, 2)`  to match the WHERE clause. 

The SQL itself has been tested by querying the DB. The SQL hasn't been tested by running a migration on a DB.