### PR TITLE
873: instead of calculating lastmilestonedate in materialized view, use dcp_lastmilestonedate field

### DIFF
--- a/migrations/materialized-view-definition.sql
+++ b/migrations/materialized-view-definition.sql
@@ -17,8 +17,7 @@ SELECT dcp_project.*,
     WHEN dcp_applicant_customer$type = 'contact' THEN contact.fullname
     WHEN dcp_applicant_customer$type = 'account' THEN account.name
   END AS applicants,
-  STRING_AGG(DISTINCT keywords.dcp_keyword, ';') AS keywords,
-  lastmilestonedates.lastmilestonedate
+  STRING_AGG(DISTINCT keywords.dcp_keyword, ';') AS keywords
 FROM dcp_project
 LEFT JOIN (
   SELECT *
@@ -114,7 +113,7 @@ LEFT JOIN (
 ) keywords
 ON keywords.dcp_project = dcp_project.dcp_projectid
 LEFT JOIN (
-  SELECT dcp_project, MAX(dcp_actualenddate) as lastmilestonedate FROM (
+  SELECT dcp_project FROM (
     SELECT dcp_project, dcp_milestone.dcp_name, dcp_actualenddate, dcp_milestone.dcp_milestoneid FROM dcp_projectmilestone mm
       LEFT JOIN dcp_milestone
          ON mm.dcp_milestone = dcp_milestone.dcp_milestoneid
@@ -146,6 +145,5 @@ LEFT JOIN (
 GROUP BY
   dcp_project.dcp_projectid,
   dcp_project.dcp_publicstatus,
-  lastmilestonedates.lastmilestonedate,
   contact.fullname, account.name
 )


### PR DESCRIPTION
Instead of calculating `lastmilestonedate` with 

`SELECT dcp_project, MAX(dcp_actualenddate) as lastmilestonedate FROM (`, 

just grab `dcp_lastmilestonedate` field from `dcp_project` table. 

**NOTE**: We were already grabbing `dcp_lastmilestonedate` field in the previous materialized view, this PR just removes the excess calculations of `lastmilestonedate`

Related to frontend PR [#1043](https://github.com/NYCPlanning/labs-zap-search/pull/1043)

Addresses Issue [#873](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/873)