### PR TITLE
1045: replace dcp_milestoneoutcome in project entity with outcome

### DIFF
--- a/src/project/project.entity.ts
+++ b/src/project/project.entity.ts
@@ -73,7 +73,7 @@ export const MILESTONE_KEYS = [
   'display_name',
   'display_date',
   'display_date2',
-  'dcp_milestoneoutcome',
+  'outcome',
   'milestone_links',
   'is_revised',
 ];


### PR DESCRIPTION
- We are currently renaming the field `dcp_milestoneoutcome.dcp_name` as `outcome` in projects/show.sql and assignments/index.sql
- This PR replaces `dcp_milestoneoutcome` with `outcome` in MILESTONE_KEYS in the project entity so that it can be accessible from the frontend

SQL: `dcp_milestoneoutcome.dcp_name AS outcome`

Related to frontend PR [#1051](https://github.com/NYCPlanning/labs-zap-search/pull/1051)

Addresses issue [#1045](https://app.zenhub.com/workspaces/zap-search-5ca2355cd9fcf5278d715938/issues/nycplanning/labs-zap-search/1045)