### PR TITLE
dont show inactive co-applicants

### DIFF
--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -367,17 +367,17 @@ SELECT
         dcp_projectapplicant.dcp_applicant_customer AS id,
         dcp_projectapplicant.dcp_applicant_customer$type AS type,
         CASE
-          WHEN dcp_applicantadministrator_customer$type = 'contact' THEN contact.fullname
-          WHEN dcp_applicantadministrator_customer$type = 'account' THEN account.name
+          WHEN dcp_projectapplicant.dcp_applicant_customer$type = 'contact' THEN contact.fullname
+          WHEN dcp_projectapplicant.dcp_applicant_customer$type = 'account' THEN account.name
         END AS name,
         dcp_projectapplicant.dcp_applicantrole AS role,
         'Project Applicant Record' AS source
         FROM dcp_projectapplicant
-        LEFT JOIN dcp_project ON dcp_projectapplicant.dcp_project = p.dcp_projectid
         LEFT JOIN contact ON contact.contactid = dcp_projectapplicant.dcp_applicant_customer
         LEFT JOIN account ON account.accountid = dcp_projectapplicant.dcp_applicant_customer
-        WHERE dcp_project.dcp_projectid = p.dcp_projectid
+        WHERE dcp_projectapplicant.dcp_project = p.dcp_projectid
         AND dcp_applicantrole = 'Co-Applicant'
+        AND dcp_projectapplicant.statecode = 'Inactive'
       )
     ) pa
   ) AS applicantteam,

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -377,7 +377,7 @@ SELECT
         LEFT JOIN account ON account.accountid = dcp_projectapplicant.dcp_applicant_customer
         WHERE dcp_projectapplicant.dcp_project = p.dcp_projectid
         AND dcp_applicantrole = 'Co-Applicant'
-        AND dcp_projectapplicant.statecode = 'Inactive'
+        AND dcp_projectapplicant.statecode <> 'Inactive'
       )
     ) pa
   ) AS applicantteam,


### PR DESCRIPTION
LUR has complained that inactive co-applicant records are being included on the public project profiles. The query failed to check for the status of applicant team records, so I added the dcp_projectapplicant.statecode <> 'Inactive' criteria. I also realized the query was doing an unnecessary table join in line 376 and referencing the wrong columns in 370 and 371.

Project to check: https://zap.planning.nyc.gov/projects/P2015K0393 
CRM project ID '69BD16F5-1733-E811-812A-1458D04D06C8'

Also closes https://github.com/NYCPlanning/labs-zap-search/issues/1092