### PR TITLE
42: update project public status values to reflect CRM update

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Use query Parameters for filtering:
 
     `dcp_femafloodzoneshadedx` *default false* - flood zone boolean
 
-    `dcp_publicstatus[] ` *default ['Filed','Certified/Referred','Approved','Disapproved','Withdrawn/Terminated/Disapproved', 'Unknown']* - the project's public status
+    `dcp_publicstatus[] ` *default ['Prefiled', Filed', 'In Public Review', Completed']* - the project's public status
 
     `dcp_certifiedreferred[]` - array of unix epoch timestamps to filter for date range
 

--- a/migrations/1581626615439_update-public-status.js
+++ b/migrations/1581626615439_update-public-status.js
@@ -1,0 +1,162 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.dropMaterializedView('normalized_projects');
+  pgm.createMaterializedView('normalized_projects',
+    {},
+    `
+    SELECT dcp_project.*,
+      CASE
+        WHEN dcp_project.dcp_publicstatus = 'Prefiled' THEN 'Prefiled'
+        WHEN dcp_project.dcp_publicstatus = 'Filed' THEN 'Filed'
+        WHEN dcp_project.dcp_publicstatus = 'In Public Review' THEN 'In Public Review'
+        WHEN dcp_project.dcp_publicstatus = 'Completed' THEN 'Completed'
+        ELSE 'Unknown'
+      END AS dcp_publicstatus_simp,
+      STRING_AGG(DISTINCT LEFT(actions.dcp_name, 2), ';') AS actiontypes,
+      STRING_AGG(DISTINCT actions.dcp_ulurpnumber, ';') AS ulurpnumbers,
+      STRING_AGG(DISTINCT dcp_projectbbl.dcp_validatedblock, ';') AS blocks,
+      STRING_AGG(DISTINCT dcp_projectbbl.dcp_bblnumber, ';') as bbls,
+      CASE
+        WHEN dcp_applicant_customer$type = 'contact' THEN contact.fullname
+        WHEN dcp_applicant_customer$type = 'account' THEN account.name
+      END AS applicants,
+      STRING_AGG(DISTINCT keywords.dcp_keyword, ';') AS keywords,
+      lastmilestonedates.lastmilestonedate
+    FROM dcp_project
+    LEFT JOIN (
+      SELECT *
+      FROM dcp_projectaction
+      WHERE statuscode <> 'Mistake'
+      AND LEFT(dcp_name, 2) IN (
+        'BD',
+        'BF',
+        'CM',
+        'CP',
+        'DL',
+        'DM',
+        'EB',
+        'EC',
+        'EE',
+        'EF',
+        'EM',
+        'EN',
+        'EU',
+        'GF',
+        'HA',
+        'HC',
+        'HD',
+        'HF',
+        'HG',
+        'HI',
+        'HK',
+        'HL',
+        'HM',
+        'HN',
+        'HO',
+        'HP',
+        'HR',
+        'HS',
+        'HU',
+        'HZ',
+        'LD',
+        'MA',
+        'MC',
+        'MD',
+        'ME',
+        'MF',
+        'ML',
+        'MM',
+        'MP',
+        'MY',
+        'NP',
+        'PA',
+        'PC',
+        'PD',
+        'PE',
+        'PI',
+        'PL',
+        'PM',
+        'PN',
+        'PO',
+        'PP',
+        'PQ',
+        'PR',
+        'PS',
+        'PX',
+        'RA',
+        'RC',
+        'RS',
+        'SC',
+        'TC',
+        'TL',
+        'UC',
+        'VT',
+        'ZA',
+        'ZC',
+        'ZD',
+        'ZJ',
+        'ZL',
+        'ZM',
+        'ZP',
+        'ZR',
+        'ZS',
+        'ZX',
+        'ZZ'
+      )
+    ) actions
+      ON actions.dcp_project = dcp_project.dcp_projectid
+    LEFT JOIN dcp_projectbbl
+      ON dcp_projectbbl.dcp_project = dcp_project.dcp_projectid
+    LEFT JOIN contact ON contact.contactid = dcp_project.dcp_applicant_customer
+    LEFT JOIN account ON account.accountid = dcp_project.dcp_applicant_customer
+    LEFT JOIN (
+        SELECT dcp_project, dcp_keyword.dcp_keyword
+        FROM dcp_projectkeywords
+        LEFT JOIN dcp_keyword
+        ON dcp_projectkeywords.dcp_keyword = dcp_keyword.dcp_keywordid
+    ) keywords
+    ON keywords.dcp_project = dcp_project.dcp_projectid
+    LEFT JOIN (
+      SELECT dcp_project, MAX(dcp_actualenddate) as lastmilestonedate FROM (
+        SELECT dcp_project, dcp_milestone.dcp_name, dcp_actualenddate, dcp_milestone.dcp_milestoneid FROM dcp_projectmilestone mm
+          LEFT JOIN dcp_milestone
+            ON mm.dcp_milestone = dcp_milestone.dcp_milestoneid
+          WHERE dcp_milestone.dcp_milestoneid IN (
+            '683beec4-dad0-e711-8116-1458d04e2fb8',
+            '6c3beec4-dad0-e711-8116-1458d04e2fb8',
+            '743beec4-dad0-e711-8116-1458d04e2fb8',
+            '783beec4-dad0-e711-8116-1458d04e2fb8',
+            '7c3beec4-dad0-e711-8116-1458d04e2fb8',
+            '7e3beec4-dad0-e711-8116-1458d04e2fb8',
+            '823beec4-dad0-e711-8116-1458d04e2fb8',
+            '843beec4-dad0-e711-8116-1458d04e2fb8',
+            '863beec4-dad0-e711-8116-1458d04e2fb8',
+            '8e3beec4-dad0-e711-8116-1458d04e2fb8',
+            '923beec4-dad0-e711-8116-1458d04e2fb8',
+            '943beec4-dad0-e711-8116-1458d04e2fb8',
+            '963beec4-dad0-e711-8116-1458d04e2fb8',
+            'a43beec4-dad0-e711-8116-1458d04e2fb8',
+            '9e3beec4-dad0-e711-8116-1458d04e2fb8',
+            'a63beec4-dad0-e711-8116-1458d04e2fb8',
+            'a83beec4-dad0-e711-8116-1458d04e2fb8',
+            'aa3beec4-dad0-e711-8116-1458d04e2fb8'
+          )
+          AND mm.statuscode <> 'Overridden'
+        AND mm.dcp_actualenddate::date <= CURRENT_DATE
+        )x GROUP BY dcp_project
+    ) lastmilestonedates
+      ON lastmilestonedates.dcp_project = dcp_project.dcp_projectid
+    GROUP BY
+      dcp_project.dcp_projectid,
+      dcp_project.dcp_publicstatus,
+      lastmilestonedates.lastmilestonedate,
+      contact.fullname, account.name
+    `);
+};
+
+exports.down = (pgm) => {
+
+};

--- a/migrations/1581626615439_update-public-status.js
+++ b/migrations/1581626615439_update-public-status.js
@@ -1,4 +1,8 @@
 /* eslint-disable camelcase */
+// Updates line 12 through 18
+// Updated CASE statement for dcp_publicstatus to reflect CRM data updates.
+// dcp_publicstatus values in CRM have been changed to 
+// "Prefiled", "Filed", "In Public Review", "Completed"
 
 exports.shorthands = undefined;
 

--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -117,7 +117,7 @@ lups_project_assignments_filtered AS (
   FROM lups_project_assignments_with_tab
   WHERE
     dcp_lupteammemberrole <> 'BB' -- this drops all BB records except for the two conditions below
-    OR (dcp_lupteammemberrole = 'BB' AND tab = 'upcoming' AND dcp_publicstatus = 'Certified/Referred')
+    OR (dcp_lupteammemberrole = 'BB' AND tab = 'upcoming' AND dcp_publicstatus = 'In Public Review')
     OR (dcp_lupteammemberrole = 'BB' AND tab = 'to-review')
 )
 
@@ -433,11 +433,10 @@ SELECT
         dcp_projectcompleted,
         dcp_publicstatus,
         CASE
+          WHEN dcp_publicstatus = 'Prefiled' THEN 'Prefiled'
           WHEN dcp_publicstatus = 'Filed' THEN 'Filed'
-          WHEN dcp_publicstatus = 'Certified/Referred' THEN 'In Public Review'
-          WHEN dcp_publicstatus = 'Approved' THEN 'Completed'
-          WHEN dcp_publicstatus = 'Disapproved' THEN 'Completed'
-          WHEN dcp_publicstatus = 'Withdrawn/Terminated/Disapproved' THEN 'Completed'
+          WHEN dcp_publicstatus = 'In Public Review' THEN 'In Public Review'
+          WHEN dcp_publicstatus = 'Completed' THEN 'Completed'
           ELSE 'Unknown'
         END AS dcp_publicstatus_simp,
         (

--- a/queries/helpers/generate-vector-tile.sql
+++ b/queries/helpers/generate-vector-tile.sql
@@ -18,8 +18,9 @@ FROM (
   ) x, tilebounds
   WHERE x.$6^ && tilebounds.geom
   ORDER BY CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1
-                WHEN dcp_publicstatus_simp = 'Filed' then 2
-                WHEN dcp_publicstatus_simp = 'Completed' then 3
-                ELSE 4
+                WHEN dcp_publicstatus_simp = 'Prefiled' then 2
+                WHEN dcp_publicstatus_simp = 'Filed' then 3
+                WHEN dcp_publicstatus_simp = 'Completed' then 4
+                ELSE 5
            END DESC
 ) q

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -18,9 +18,10 @@ WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   ${radiusDistanceQuery^}
   ${blockQuery^}
 ORDER BY lastmilestonedate DESC NULLS LAST,
-CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1
-      WHEN dcp_publicstatus_simp = 'Filed' then 2
-      WHEN dcp_publicstatus_simp = 'Completed' then 3
-            ELSE 4
+CASE  WHEN dcp_publicstatus_simp = 'In Public Review' then 1
+      WHEN dcp_publicstatus_simp = 'Prefiled' then 2
+      WHEN dcp_publicstatus_simp = 'Filed' then 3
+      WHEN dcp_publicstatus_simp = 'Completed' then 4
+            ELSE 5
         END ASC
 ${paginate^}

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -26,11 +26,10 @@ SELECT
   dcp_femafloodzonev,
   dcp_projectcompleted,
   CASE
+    WHEN p.dcp_publicstatus = 'Prefiled' THEN 'Prefiled'
     WHEN p.dcp_publicstatus = 'Filed' THEN 'Filed'
-    WHEN p.dcp_publicstatus = 'Certified/Referred' THEN 'In Public Review'
-    WHEN p.dcp_publicstatus = 'Approved' THEN 'Completed'
-    WHEN p.dcp_publicstatus = 'Disapproved' THEN 'Completed'
-    WHEN p.dcp_publicstatus = 'Withdrawn/Terminated/Disapproved' THEN 'Completed'
+    WHEN p.dcp_publicstatus = 'In Public Review' THEN 'In Public Review'
+    WHEN p.dcp_publicstatus = 'Completed' THEN 'Completed'
     ELSE 'Unknown'
   END AS dcp_publicstatus_simp,
   (


### PR DESCRIPTION
Previously we were recoding `dcp_publicstatus` values we received from
CRM. The column name in the materialized view is `dcp_publicstatus_simp`.

A CRM system update will align language used in the CRM database to
business practice language. We were previously recoding CRM database
values to match this business practice language. This recoding is no
longer necessary. This business practice language includes four values:
"Prefiled", "Filed", "In Public Review", "Completed".

This commit updates the ZAP API backend to receive the new project
status values from CRM.

**TODO:**
Requires manual migration to be run on target database (local,
ZAP staging, or ZAP Prod).

Addresses #42 

**WAITING TO MERGE UNTIL TESTED ON UAT2**