### PR TITLE
Generate default tile query if no cache found

### DIFF
--- a/src/project/project.controller.spec.ts
+++ b/src/project/project.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TilesService } from './tiles/tiles.service';
+import { ConfigService } from '../config/config.service';
 import { ProjectService } from './project.service';
 import { GeometriesService } from './geometries/geometries.service';
 import { ProjectController } from './project.controller';
@@ -26,6 +27,10 @@ describe('Project Controller', () => {
           // how you provide the injection token in a test instance
           useValue: new (class ProjectServiceMock { }),
         },
+        {
+          provide: ConfigService,
+          useValue: new (class ConfigServiceMock { }),
+        }
       ],
     }).compile();
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -20,7 +20,6 @@ import { Octokit } from '@octokit/rest';
 
 const findProjectQuery = getQueryFile('/projects/show.sql');
 const boundingBoxQuery = getQueryFile('helpers/bounding-box-query.sql');
-const tileQuery = getQueryFile('helpers/tile-query.sql');
 
 function extractMeta(projects = []) {
   const [{ total_projects: total = 0 } = {}] = projects;
@@ -83,7 +82,7 @@ export class ProjectService {
      */
     const projectIds = await this.projectRepository.query(buildProjectsSQL(request, 'projectids'));
     const projectIdsString = projectIds.map(d => d.projectid).map(d => `'${d}'`).join(',');
-    const tileSQL = pgp.as.format(tileQuery, { projectIds: projectIdsString });
+    const tileSQL = this.tiles.generateTileSQL(projectIdsString);
 
     // create array of projects that have geometry
     const projectsWithGeometries = projects.filter(project => project.has_centroid);

--- a/src/project/tiles/tiles.service.ts
+++ b/src/project/tiles/tiles.service.ts
@@ -10,6 +10,7 @@ import { Project } from '../project.entity';
 import { getQueryFile } from '../../_utils/get-query-file';
 
 const generateVectorTile = getQueryFile('/helpers/generate-vector-tile.sql');
+const tileQuery = getQueryFile('helpers/tile-query.sql');
 
 @Injectable()
 export class TilesService {
@@ -37,9 +38,14 @@ export class TilesService {
     return tileId;
   }
 
+  generateTileSQL(projectIds: string) {
+    return pgp.as.format(tileQuery, { projectIds });
+  }
+
   async generateTile(type, tileId, x, y, z) {
     // retreive the projectids from the cache
-    const tileQuery = await this.get(tileId);
+    // default to a blank query if no cache is found
+    const tileQuery = await this.get(tileId) || this.generateTileSQL('-1');
 
     // calculate the bounding box for this tile
     const bbox = this.mercator.bbox(x, y, z, false, '900913');


### PR DESCRIPTION
Closes #108

Generates a default “empty” query if no cache is found. This prevents errors from flooding the logs.

Pulls tile query generation into tiles service, from controller;