### PR TITLE
Fix blank "token" cookie

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -23,7 +23,7 @@ export class AppController {
     try {
       const ZAPToken = await this.authService.generateNewToken(NYCIDToken);
 
-      res.cookie('token', ZAPToken)
+      res.cookie('token', ZAPToken, { httpOnly: true })
         .send({ message: 'Login successful!' });
     } catch (e) {
       if (e instanceof HttpException) {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -23,7 +23,7 @@ export class AppController {
     try {
       const ZAPToken = await this.authService.generateNewToken(NYCIDToken);
 
-      res.cookie('token', ZAPToken, { httpOnly: true })
+      res.cookie('token', ZAPToken)
         .send({ message: 'Login successful!' });
     } catch (e) {
       if (e instanceof HttpException) {

--- a/src/auth.middleware.ts
+++ b/src/auth.middleware.ts
@@ -3,7 +3,7 @@ import { AuthService } from './auth/auth.service';
 
 function proceedNoAuth(res, next) {
   // TODO: understand why this was necessary
-  // res.clearCookie('token');
+  res.clearCookie('token');
   next();
 }
 
@@ -15,6 +15,13 @@ export class AuthMiddleware implements NestMiddleware {
     req.session = false;
 
     const { token } = req.cookies;
+
+    // skip for the login route
+    if (req.originalUrl.includes('login')) {
+      next();
+
+      return;
+    }
 
     try {
       req.session = await this.authService.validateCurrentToken(token);

--- a/src/auth.middleware.ts
+++ b/src/auth.middleware.ts
@@ -2,7 +2,8 @@ import { Injectable, NestMiddleware } from '@nestjs/common';
 import { AuthService } from './auth/auth.service';
 
 function proceedNoAuth(res, next) {
-  res.clearCookie('token');
+  // TODO: understand why this was necessary
+  // res.clearCookie('token');
   next();
 }
 


### PR DESCRIPTION
This PR skips the authentication middleware for the login route only.

Originally, when auth middleware detected no token, it would clear the current token. This was occurring in the same breath as a token being created and sent. In all browsers, there would be two tokens provided with the response:

```
token: 
token: <real jwt>
```

I think we saw inconsistent behavior because of how browsers/OS decide which token to take — the blank or the real one! Safari preferred the blank? And Chrome preferred the real one? Maybe it's how they resolve duplicate cookies? Not sure.



