### PR TITLE
Hotfix sameSite none and secure set to true

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -23,7 +23,7 @@ export class AppController {
     try {
       const ZAPToken = await this.authService.generateNewToken(NYCIDToken);
 
-      res.cookie('token', ZAPToken, { httpOnly: true })
+      res.cookie('token', ZAPToken, { httpOnly: true, sameSite: 'none', secure: true })
         .send({ message: 'Login successful!' });
     } catch (e) {
       if (e instanceof HttpException) {


### PR DESCRIPTION
This hotfix enables some options for ZAP API cookies that are now required in Chrome:

https://web.dev/samesite-cookies-explained/

Unclear whether this fixes the issue with Safari login. 