### PR TITLE
add lup project "uncategorized" label

### DIFF
--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -90,6 +90,8 @@ lups_project_assignments_with_tab AS (
         AND lups_dispositions_status.statecode IN ('Inactive', '1')
         AND lups_dispositions_status.statuscode IN ('Submitted', 'Not Submitted', '2', '717170002') -- status becomes submitted once they submit recommendation
         THEN 'reviewed'
+      ELSE
+        'uncategorized'
     END AS tab,
     lups_project_assignments_all.*,
     -- note: the following attributes aren't used in the assignment model; they're only included to help verify that the tab logic is correct


### PR DESCRIPTION
It's difficult to investigate why some projects aren't showing up in the LUP dashboard, because we lose projects that don't get assigned a tab label (i.e. there's no way to look for them in the API response because their tab attribute is null). I've added an "uncategorized" tab label for projects that are assigned to the user but don't get properly sorted onto 'upcoming', 'to-review', 'reviewed', or 'archive'. This way we can see if projects users say are missing are indeed 'uncategorized' using the `&tab=uncategorized` URL parameter.